### PR TITLE
Fix deep link info for overview card

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,3 +1,3 @@
 {
-  "contributors": ["aarlaud","punkle"]
+  "contributors": ["aarlaud","punkle", "nicolasarnold12321"]
 }

--- a/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
+++ b/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
@@ -142,7 +142,7 @@ export const SnykOverviewComponent = ({ entity }: { entity: Entity }) => {
 
   const linkInfo = {
     title: `Across ${projectsCount} project${projectsCount > 0 ? "s" : ""}`,
-    link: `snyk`,
+    link: `snyk/`,
   };
 
   return (


### PR DESCRIPTION
This change here appends a `/` to the end of the link. By doing so, it will allow the users to navigate to the snyk
plugin card that will display all the know vulnerabilities.

Signed-off-by: Nicolas Arnold <nic@roadie.io>

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

_Explain why this PR exists_

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_