### PR TITLE
Add isSnykAvailable switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ The plugin is composed of 2 main parts
 a. Import the elements
 ```
 // packages/app/src/components/catalog/EntityPage.tsx
-import { SnykOverview, EntitySnykContent } from 'backstage-plugin-snyk';
+import {
+  isPluginApplicableToEntity as isSnykAvailable,
+  SnykOverview,
+  EntitySnykContent,
+} from '@backstage/backstage-plugin-snyk';
 ```
 
 b. Add the overview card\
@@ -49,9 +53,13 @@ b. Add the overview card\
 const overviewContent = (
   <Grid container spacing={3} alignItems="stretch">
     ...
-    <Grid item>        
-      <SnykOverview />
-    </Grid>
+    <EntitySwitch>
+    <EntitySwitch.Case if={isSnykAvailable}>
+      <Grid item md={6}>
+        <SnykOverview />
+      </Grid>
+    </EntitySwitch.Case>
+    </EntitySwitch>
     ...
   </Grid>
 );

--- a/src/components/SnykEntityComponent/index.ts
+++ b/src/components/SnykEntityComponent/index.ts
@@ -1,2 +1,6 @@
+import { Entity } from '@backstage/catalog-model';
+
 export { SnykEntityComponent } from "./SnykEntityComponent";
 export { SnykOverview } from "./SnykOverviewComponent";
+export const isPluginApplicableToEntity = (entity: Entity) =>
+    Boolean(entity.metadata.annotations?.["snyk.io/org-name"]) && Boolean(entity.metadata.annotations?.["snyk.io/project-ids"]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,7 @@ export {
   SnykOverview,
   EntitySnykContent,
 } from "./plugin";
+export {
+  isPluginApplicableToEntity,
+  isPluginApplicableToEntity as isSnykAvailable,
+} from './components/SnykEntityComponent';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Adds in a `isSnykAvailable` switch. Because 99% of users will not have setup the Snyk plugin, this gives and opportunity to write instructions on how to set it up, instead of a funny gif. Or just not show the panel if it is not setup yet. This is exactly how the PagerDuty plugin (included in the official backstage/backstage repo) does it.

Resolves #60 

### Notes for the reviewer

I tested this locally. The code is directly copied from the PagerDuty plugin: https://github.com/backstage/backstage/tree/master/plugins/pagerduty