### PR TITLE
fix: deprecation notice for createComponentExtension

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,6 +50,7 @@ export const EntitySnykContent = backstagePluginSnykPlugin.provide(
 
 export const SnykOverview = backstagePluginSnykPlugin.provide(
   createComponentExtension({
+    name: 'SnykOverview',
     component: {
       lazy: () =>
         import("./components/SnykEntityComponent").then((m) => m.SnykOverview),


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

There is a deprecation notice when calling `createComponentExtension` without a name.

### More information

- [Link to documentation](https://github.com/backstage/backstage/blob/e9496f746b31600dbfac7fa76987479e66426257/packages/core-plugin-api/CHANGELOG.md#patch-changes-12)
