### PR TITLE
fix: handle missing annotation case and bump node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build-test-monitor:
       docker:
         # specify the version
-        - image: cimg/node:16.18.0
+        - image: cimg/node:18.19.0
 
       steps:
         - checkout
@@ -31,7 +31,7 @@ jobs:
   build-test:
       docker:
         # specify the version
-        - image: cimg/node:16.18.0
+        - image: cimg/node:18.19.0
 
       steps:
         - checkout

--- a/src/components/SnykEntityComponent/SnykEntityComponent.tsx
+++ b/src/components/SnykEntityComponent/SnykEntityComponent.tsx
@@ -112,8 +112,8 @@ export const SnykEntityComponent = () => {
 
   const tabs: Array<SnykTab> = [];
 
-  const orgIds = entity?.metadata.annotations?.[SNYK_ANNOTATION_ORGS].split(',')
-    || entity?.metadata.annotations?.[SNYK_ANNOTATION_ORG].split(',')
+  const orgIds = entity?.metadata.annotations?.[SNYK_ANNOTATION_ORGS]?.split(',')
+    || entity?.metadata.annotations?.[SNYK_ANNOTATION_ORG]?.split(',')
     || [];
   const hasMultipleOrgs = orgIds.length > 1;
 

--- a/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
+++ b/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
@@ -51,8 +51,8 @@ export const SnykOverviewComponent = ({entity}: { entity: Entity }) => {
     );
   }
 
-  const orgIds = entity?.metadata.annotations?.[SNYK_ANNOTATION_ORGS].split(',')
-    || entity?.metadata.annotations?.[SNYK_ANNOTATION_ORG].split(',')
+  const orgIds = entity?.metadata.annotations?.[SNYK_ANNOTATION_ORGS]?.split(',')
+    || entity?.metadata.annotations?.[SNYK_ANNOTATION_ORG]?.split(',')
     || [];
   const hasMultipleOrgs = orgIds.length > 1;
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

Handles the split operation only if annotation exists + bump node version.