### PR TITLE
fix: expose annotation constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./plugin";
 
 export * from "./api";
+export * from "./config";
 
 export {
   isPluginApplicableToEntity,


### PR DESCRIPTION
Make writing of processors easier by exposing the annotation constants used by the plugin.

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

_Explain why this PR exists_

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_