### PR TITLE
fix(api): update `targets` endpoint to use up-to-date `projects` endpoint

### DIFF
--- a/src/components/SnykEntityComponent/SnykEntityComponent.tsx
+++ b/src/components/SnykEntityComponent/SnykEntityComponent.tsx
@@ -26,7 +26,6 @@ import {
   mdiLambda,
 } from "./svgs";
 import {useEntity} from "@backstage/plugin-catalog-react";
-import {ProjectsData} from "../../types/projectsTypes";
 import {
   SNYK_ANNOTATION_ORG,
   SNYK_ANNOTATION_ORGS,
@@ -119,11 +118,7 @@ export const SnykEntityComponent = () => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {value, loading, error} = useAsync(async () => {
-    return Promise.all(orgIds.map(async (orgId) => {
-      const projectList: ProjectsData[] = entity?.metadata.annotations ? await snykApi.getCompleteProjectsListFromAnnotations(orgId, entity?.metadata.annotations, hasMultipleOrgs) : []
-      const orgSlug = await snykApi.getOrgSlug(orgId);
-      return {projectList, orgSlug, orgId};
-    }));
+    return snykApi.getCompleteProjectsListForMultipleOrgs(orgIds, entity?.metadata.annotations ?? {});
   });
   if (loading) {
     return (

--- a/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
+++ b/src/components/SnykEntityComponent/SnykOverviewComponent.tsx
@@ -54,7 +54,6 @@ export const SnykOverviewComponent = ({entity}: { entity: Entity }) => {
   const orgIds = entity?.metadata.annotations?.[SNYK_ANNOTATION_ORGS]?.split(',')
     || entity?.metadata.annotations?.[SNYK_ANNOTATION_ORG]?.split(',')
     || [];
-  const hasMultipleOrgs = orgIds.length > 1;
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {value, loading, error} = useAsync(async () => {
@@ -64,17 +63,7 @@ export const SnykOverviewComponent = ({entity}: { entity: Entity }) => {
       medium: 0,
       low: 0,
     };
-    const projectOrgList = await Promise.all(
-      orgIds.map(async (orgId) => {
-        const projectList = entity?.metadata.annotations
-          ? await snykApi.getCompleteProjectsListFromAnnotations(
-            orgId,
-            entity.metadata.annotations,
-            hasMultipleOrgs
-          ) : [];
-        return {projectList, orgId};
-      })
-    );
+    const projectOrgList = await snykApi.getCompleteProjectsListForMultipleOrgs(orgIds, entity?.metadata.annotations ?? {})
 
     let projectsCount = 0;
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

I noticed an edge case in the implementation of my last PR while testing this with our production setup. In the case where no projects are found in any targets the project list will be empty. This causes the API to fetch all projects from all configured orgs causing a very long list and loading time.

Before the change an error was thrown. This should also be the case for the multi org setup.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation]()

### Screenshots

_Visuals that may help the reviewer_