### PR TITLE
fix: ignore missing targets when multiple orgs are used and rename display name attribute to fit

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -378,12 +378,14 @@ export class SnykApiClient implements SnykApi {
       }
       const jsonResponse = await response.json();
       return jsonResponse.data as ProjectsData[];
-    } else {
+    } else if (!ignoreMissing) {
       throw new Error(
         `No target IDs found in org ${orgId} for the targets [${repoName.join(
           ","
         )}].`
       );
+    } else {
+      return [];
     }
   }
 
@@ -452,7 +454,7 @@ export class SnykApiClient implements SnykApi {
       const targetsList = await targetResponse.json();
       const targetsListData = targetsList.data as TargetData[];
       targetId = targetsListData.find((target) => {
-        return target.attributes.displayName === targetIdentifier;
+        return target.attributes.display_name === targetIdentifier;
       })?.id;
       if (!targetId) {
         throw new Error(

--- a/src/types/targetsTypes.ts
+++ b/src/types/targetsTypes.ts
@@ -5,7 +5,7 @@ export interface TargetDataAttributes {
      * @type {string}
      * @memberof TargetDataAttributes
      */
-    displayName?: string;
+    display_name?: string;
     /**
      * The URL for the resource. We do not use this as part of our representation of the identity of the target, as it can      be changed externally to Snyk We are reliant on individual integrations providing us with this value. Currently it is only provided by the CLI 
      * @type {string}


### PR DESCRIPTION
This fixes the remaining issues to support multiple organisations (tested in our local backstage instance).
