### PR TITLE
Bug Fix - Priority score of an issue is not displayed

### DIFF
--- a/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
+++ b/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
@@ -39,7 +39,7 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
         statusRaw: issue.attributes.status,
         description: issue.attributes.title,
         // the line below is changed from priority.score
-        priority: issue.attributes.risk?.score.value || "",
+        priority: issue.attributes.priority?.score || issue.attributes.risk?.score.value || "",
       };
 
       for (const key in values) {

--- a/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
+++ b/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
@@ -14,7 +14,7 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
     { title: "Type", field: "type" },
     { title: "Status", field: "status" },
     { title: "Description", field: "description" },
-    { title: "Priority Score", field: "priority" },
+    { title: "Score", field: "score" },
   ];
 
   const data = issues
@@ -38,8 +38,8 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
         status: issue.attributes.status,
         statusRaw: issue.attributes.status,
         description: issue.attributes.title,
-        // two possible locations where the numeric value of a priority score is stored
-        priority: issue.attributes.priority?.score || issue.attributes.risk?.score.value || "",
+        // either gets a priority score or a risk score
+        score: issue.attributes.priority?.score || issue.attributes.risk?.score.value || "",
       };
 
       for (const key in values) {
@@ -71,7 +71,7 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
         if (a.statusRaw === "resolved" && b.statusRaw === "resolved") {
           return severity[a.severityRaw] < severity[b.severityRaw] ? 1 : -1;
         }
-        return a.priority < b.priority ? 1 : -1;
+        return a.score < b.score ? 1 : -1;
       }
       return severity[a.severityRaw] < severity[b.severityRaw] ? 1 : -1;
     });

--- a/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
+++ b/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
@@ -38,7 +38,7 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
         status: issue.attributes.status,
         statusRaw: issue.attributes.status,
         description: issue.attributes.title,
-        // the line below is changed from priority.score
+        // two possible locations where the numeric value of a priority score is stored
         priority: issue.attributes.priority?.score || issue.attributes.risk?.score.value || "",
       };
 

--- a/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
+++ b/src/components/SnykEntityComponent/components/SnykIssuesComponent.tsx
@@ -38,7 +38,8 @@ export const IssuesTable: FC<DenseTableProps> = ({ issues, pageUrl }) => {
         status: issue.attributes.status,
         statusRaw: issue.attributes.status,
         description: issue.attributes.title,
-        priority: issue.attributes.priority?.score || "",
+        // the line below is changed from priority.score
+        priority: issue.attributes.risk?.score.value || "",
       };
 
       for (const key in values) {

--- a/src/types/unifiedIssuesTypes.ts
+++ b/src/types/unifiedIssuesTypes.ts
@@ -159,7 +159,7 @@ export interface Priority {
 
 export interface Score {
   /**
- * An array of factors that contributed to scoring.
+ * A model version as string.
  * @type {string}
  * @memberof Score
  */
@@ -180,7 +180,7 @@ export interface Risk {
    */
     factors?: Array<PriorityFactor>;
     /**
-     * A numeric priority score from 0 to 1000 determined by snyk.
+     * A priority score determined by snyk.
      * @type {Score}
      * @memberof Risk
      */

--- a/src/types/unifiedIssuesTypes.ts
+++ b/src/types/unifiedIssuesTypes.ts
@@ -157,6 +157,36 @@ export interface Priority {
   score: number;
 }
 
+export interface Score {
+  /**
+ * An array of factors that contributed to scoring.
+ * @type {string}
+ * @memberof Score
+ */
+  model?: string;
+  /**
+   * A numeric priority score from 0 to 1000 determined by snyk.
+   * @type {number}
+   * @memberof Score
+   */
+  value: number;
+}
+
+export interface Risk {
+    /**
+   * An array of factors that contributed to scoring.
+   * @type {Array<PriorityFactor>}
+   * @memberof Risk
+   */
+    factors?: Array<PriorityFactor>;
+    /**
+     * A numeric priority score from 0 to 1000 determined by snyk.
+     * @type {Score}
+     * @memberof Risk
+     */
+    score: Score;
+}
+
 export enum ProblemTypeDef {
   Rule = "rule",
   Vulnerability = "vulnerability",
@@ -340,6 +370,12 @@ export interface IssueAttributes {
    * @memberof IssueAttributes
    */
   priority?: Priority;
+  /**
+   *
+   * @type {Risk}
+   * @memberof IssueAttributes
+   */
+  risk?: Risk;
   /**
    * A list of details for vulnerability data, policy, etc that are the source of this issue.
    * @type {Array<Problem>}


### PR DESCRIPTION
This PR fixes the issue I raised - #206 

No priority scores were displayed for project's issues.

### What this does

Adds another location within the json response from snyk where to get the value of a priority score of an issue.

### Notes for the reviewer

See commit changes - added a new attribute of an issue to unifiedIssuesTypes.ts and referenced the new location in SnykIssuesComponent.tsx.
